### PR TITLE
add github workflow action for building and added x86_64 build target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,10 @@ jobs:
       run: |
         cd build
         go run .
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        path: |
+          build/tmp/*.tar.gz
+          build/tmp/*.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+# This workflow will build ccu-jack
+
+name: CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.21.x'
+
+    - name: Build
+      run: |
+        cd build
+        go run .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,5 @@ jobs:
         path: |
           ccu-jack-*.tar.gz
           ccu-jack-*.zip
+        name: ccu-jack-${{ github.sha }}
+        retention-days: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,5 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         path: |
-          build/tmp/*.tar.gz
-          build/tmp/*.zip
+          ccu-jack-*.tar.gz
+          ccu-jack-*.zip

--- a/build/main.go
+++ b/build/main.go
@@ -39,6 +39,7 @@ var (
 		"ccu3-rm-rp2+3": {true, releng.GoSpec{OS: "linux", Arch: "arm", Arm: "7", LDFlags: ldFlags}},
 		"rm-rp4":        {true, releng.GoSpec{OS: "linux", Arch: "arm64", LDFlags: ldFlags}},
 		"vccu-x86":      {true, releng.GoSpec{OS: "linux", Arch: "386", LDFlags: ldFlags}},
+		"vccu-x86_64":   {true, releng.GoSpec{OS: "linux", Arch: "amd64", LDFlags: ldFlags}},
 		"win":           {false, releng.GoSpec{OS: "windows", Arch: "amd64", LDFlags: ldFlags}},
 		"linux":         {false, releng.GoSpec{OS: "linux", Arch: "amd64", LDFlags: ldFlags}},
 		"darwin":        {false, releng.GoSpec{OS: "darwin", Arch: "amd64", LDFlags: ldFlags}},

--- a/build/main.go
+++ b/build/main.go
@@ -25,6 +25,7 @@ var (
 		"rm-rp0+1",
 		"rm-rp4",
 		"vccu-x86",
+		"vccu-x86_64",
 		"win",
 		"linux",
 		"darwin",


### PR DESCRIPTION
This PR refs #162 by adding x86_64 as an addon build target to the build/main.go file so that a 64bit addon archive is generated alonside the other addon targets.

In addition, this PR also adds a first basic github workflow CI file to allow ccu-jack to be build via github actions and upload all build *.tar.gz/*.zip files as a build artifact that can be downloaded for testing purposes. Based on this workflow a "release" workflow could be generated which (instead of a manual build+release) could take care of the whole release cycle.