### PR TITLE
monit-ccu-jack.cfg fixes

### DIFF
--- a/dist/ccu/etc/monit-ccu-jack.cfg
+++ b/dist/ccu/etc/monit-ccu-jack.cfg
@@ -7,8 +7,7 @@ check process ccu-jack with pidfile /var/run/ccu-jack.pid
     restart = "/etc/config/rc.d/ccu-jack restart"
     if does not exist then
         exec "/bin/triggerAlarm.tcl 'CCU-Jack nicht aktiv' 'WatchDog: CCU-Jack' true"
-    if failed port 2121 for 2 cycles then
+    if failed port 2121 protocol http for 5 cycles then
         exec "/bin/triggerAlarm.tcl 'CCU-Jack Port 2121 nicht erreichbar' 'WatchDog: CCU-Jack' true"
-    if failed port 2122 for 2 cycles then
+    if failed port 2122 protocol https for 5 cycles then
         exec "/bin/triggerAlarm.tcl 'CCU-Jack Port 2122 nicht erreichbar' 'WatchDog: CCU-Jack' true"
-    depends on lighttpd, rfd, HMIPServer, ReGaHss


### PR DESCRIPTION
This PR applied changes to `monit-ccu-jack.cfg` to fix restart issues in case a service which was listed as dependent failed/crashed. For example, if ReGaHss crashes for some reason, ccu-jack is also forcefully restarted – which is not only not necessary but also might end up in CCU-Jack not being able to restart correctly again. So CCU-Jack should continue to operate regardly of lighttpd, rfd, HMIPServer or ReGaHss. In addition, we explicitly use protocol statements and prolonged cycle times before notifying on potential issues.