### PR TITLE
remove protocol definitions from ccu-jack monit cfg

### DIFF
--- a/dist/ccu/etc/monit-ccu-jack.cfg
+++ b/dist/ccu/etc/monit-ccu-jack.cfg
@@ -7,7 +7,7 @@ check process ccu-jack with pidfile /var/run/ccu-jack.pid
     restart = "/etc/config/rc.d/ccu-jack restart"
     if does not exist then
         exec "/bin/triggerAlarm.tcl 'CCU-Jack nicht aktiv' 'WatchDog: CCU-Jack' true"
-    if failed port 2121 protocol http for 5 cycles then
+    if failed port 2121 for 5 cycles then
         exec "/bin/triggerAlarm.tcl 'CCU-Jack Port 2121 nicht erreichbar' 'WatchDog: CCU-Jack' true"
-    if failed port 2122 protocol https for 5 cycles then
+    if failed port 2122 for 5 cycles then
         exec "/bin/triggerAlarm.tcl 'CCU-Jack Port 2122 nicht erreichbar' 'WatchDog: CCU-Jack' true"


### PR DESCRIPTION
This PR removes the protocol definitions from ccu-jack monit cfg because it could result in alarm messages and is more lightweight without being specified.

See https://homematic-forum.de/forum/viewtopic.php?f=85&t=85060&p=830307#p830307