### PR TITLE
docs: Auto-translate README and Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
+
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="center">
+        <a href="https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=en">English</a>
+        | <a href="https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=zh-CN">简体中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=zh-TW">繁體中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=ja">日本語</a>
+        | <a href="https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=ko">한국어</a>
+        | <a href="https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=hi">हिन्दी</a>
+        | <a href="https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=th">ไทย</a>
+        | <a href="https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=fr">Français</a>
+        | <a href="https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=de">Deutsch</a>
+        | <a href="https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=es">Español</a>
+        | <a href="https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=it">Italiano</a>
+        | <a href="https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=ru">Русский</a>
+        | <a href="https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=pt">Português</a>
+        | <a href="https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=nl">Nederlands</a>
+        | <a href="https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=pl">Polski</a>
+        | <a href="https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=ar">العربية</a>
+        | <a href="https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=fa">فارسی</a>
+        | <a href="https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=tr">Türkçe</a>
+        | <a href="https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=vi">Tiếng Việt</a>
+        | <a href="https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=id">Bahasa Indonesia</a>
+        | <a href="https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=as">অসমীয়া</
+      </div>
+    </div>
+  </details>
+</div>
+
 # CCU-Jack
 
 CCU-Jack bietet einen einfachen und sicheren **REST**- und **MQTT**-basierten Zugriff auf die Datenpunkte der Zentrale (CCU) des [Hausautomations-Systems](http://de.wikipedia.org/wiki/Hausautomation) HomeMatic der Firma [eQ-3](http://www.eq-3.de/). Er implementiert dafür das [Very Easy Automation Protocol](https://github.com/mdzio/veap), welches von vielen Programmiersprachen leicht verwendet werden kann, und das [MQTT-Protokoll](https://de.wikipedia.org/wiki/MQTT), welches im Internet-of-Things weit verbreitet ist. Zudem können mit den genannten Protokollen auch Fremdgeräte an die CCU angebungen werden.


### PR DESCRIPTION
I've enhanced the documentation accessibility by adding language badges to the README, making it easier to navigate between translated versions. Currently supported languages include German, Spanish, French, Japanese, Korean, Portuguese, Russian, and 13 additional languages.

### Key Features
- **Automatic Translation Updates**: The system automatically syncs translations for both README and Wiki content whenever the repository is updated
- **Multi-language SEO Support**: Full optimization for Google and Bing search across all supported languages

### Demo Links
Check out the translated versions:
- [English](https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=en)
- [简体中文](https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=zh-CN)
- [日本語](https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=ja)
- [한국어](https://openaitx.github.io/view.html?user=mdzio&project=ccu-jack&lang=ko)

![Demo Image](https://github.com/user-attachments/assets/7cd54a88-59c1-455f-9c7d-2db7f05b2962)

If this doesn't align with your expectations, feel free to close this PR. Thanks for your time! 🙌
